### PR TITLE
v1.26.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # khs
 
-khs is a resolver for Headless Services in Kubernetes used for (EXPERIMENTAL) Load Balancing gRPC in the client (at L4) in go.
+khs is a gRPC resolver for [Headless Services](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) in Kubernetes used for Round Robin Load Balancing (at L4) in Go.
 
+As per [Load Balancing in gRPC](https://github.com/grpc/grpc/blob/master/doc/load-balancing.md), khs enables a Balancing-Aware Client, which -as stated- has many drawbacks. However, if all (or most) of your gRPC clients are written in Go, you don't want to run Istio or write a Load Balancing service and you don't need a more complicated balancing strategy than Round Robin, this makes things very simple. 
+
+Since this project follows the grpc-go version (i.e. If you're using 1.26.X, you should use khs 1.26.X) and the resolver/balancer API is classed as EXPERIMENTAL, it does not follow the Go compatibility promise between large releases.
 
 ## Usage
 
 Add `_ "github.com/kixa/khs"` to your imports and use the `khs` scheme to dial your `Headless Service`.
 
-For Example (with the built-in `roundrobin` balancer):
+For Example:
 
 ```
 package main
@@ -23,7 +26,7 @@ import (
 )
 
 func main() {
-	conn, err := grpc.Dial("khs:///example.default<:optional_port>", grpc.WithInsecure(), grpc.WithBalancerName(roundrobin.Name))
+	conn, err := grpc.Dial("khs:///example.default<:optional_port>", grpc.WithInsecure())
 
 	if err != nil {
 		log.Fatalf("failed to dial: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/kixa/khs
 
 go 1.12
+
+require (
+	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
+	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	google.golang.org/genproto v0.0.0-20200115191322-ca5a22157cba // indirect
+	google.golang.org/grpc v1.26.0 // indirect
+)


### PR DESCRIPTION
This brings khs into line with the current state of the go gRPC Resolver/Balancer API in 1.26.0. It:
- Fixes previously deprecated types, 
- Uses `ServiceConfig` to select `round_robin` in the client.